### PR TITLE
avoid conflicting template names

### DIFF
--- a/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level102/MQConfiguration102.java
+++ b/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level102/MQConfiguration102.java
@@ -16,9 +16,11 @@
 
 package com.ibm.mq.samples.jms.spring.level102;
 
+import com.ibm.mq.samples.jms.spring.globals.handlers.OurDestinationResolver;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
@@ -34,6 +36,9 @@ public class MQConfiguration102 {
     @Autowired
     private ConnectionFactory connectionFactory;
 
+    @Value("${spring.jms.pub-sub-domain:false}")
+    public Boolean pubsub;
+
     @Bean("myPubSubTemplate")
     public JmsTemplate myPubSubJmsTemplate() {
         JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
@@ -48,12 +53,6 @@ public class MQConfiguration102 {
         return jmsTemplate;
     }
 
-    // Need this bean to override default allowing Level 101 components to work in conjunction
-    // with Level 102 components.
-    @Bean("jmsTemplate")
-    public JmsTemplate jmsTemplate() {
-        return new JmsTemplate(connectionFactory);
-    }
 
     @Bean
     public JmsListenerContainerFactory<?> mySubContainerFactory102() {
@@ -69,6 +68,20 @@ public class MQConfiguration102 {
         factory.setConnectionFactory(connectionFactory);
         factory.setPubSubDomain(false);
         return factory;
+    }
+
+    // Need this bean to override default allowing Level 101 components to work in conjunction
+    // with subsequent components
+    @Bean("jmsTemplate")
+    public JmsTemplate jmsTemplate() {
+        //return new JmsTemplate(connectionFactory);
+        JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+        if (pubsub) {
+            jmsTemplate.setPubSubDomain(true);
+        } else {
+            jmsTemplate.setPubSubDomain(false);
+        }
+        return jmsTemplate;
     }
 
 }

--- a/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level106/MQConfiguration106.java
+++ b/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level106/MQConfiguration106.java
@@ -34,13 +34,11 @@ public class MQConfiguration106 {
     @Autowired
     private ConnectionFactory connectionFactory;
 
-    @Bean("myNonJmsTemplate")
-    public JmsTemplate myNonJmsTemplate() {
+    @Bean("myNonJmsTemplate106")
+    public JmsTemplate myNonJmsTemplate106() {
         JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
         jmsTemplate.setDestinationResolver(new OurDestinationResolver());
         jmsTemplate.setMessageConverter(new OurMessageConverter());
         return jmsTemplate;
     }
-
-
 }

--- a/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level106/MessageConsumer106.java
+++ b/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level106/MessageConsumer106.java
@@ -21,6 +21,7 @@ import com.ibm.mq.samples.jms.spring.globals.handlers.OurMessageConverter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.jms.annotation.JmsListener;
+import org.springframework.stereotype.Component;
 
 
 //@Component

--- a/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level106/Scheduler106.java
+++ b/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level106/Scheduler106.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 
 //@Component
 @EnableScheduling

--- a/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level106/SendMessageService106.java
+++ b/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level106/SendMessageService106.java
@@ -29,17 +29,17 @@ public class SendMessageService106 {
     @Value("${app.l106.queue.name1}")
     public String sendQueue;
 
-    final private JmsTemplate myNonJmsTemplate;
+    final private JmsTemplate myNonJmsTemplate106;
 
-    SendMessageService106(JmsTemplate myNonJmsTemplate) {
-        this.myNonJmsTemplate = myNonJmsTemplate;
+    SendMessageService106(JmsTemplate myNonJmsTemplate106) {
+        this.myNonJmsTemplate106 = myNonJmsTemplate106;
     }
 
     public void send(OurData msg) {
-        myNonJmsTemplate.convertAndSend(sendQueue, msg);
+        myNonJmsTemplate106.convertAndSend(sendQueue, msg);
     }
     public void send(OurOtherData msg) {
-        myNonJmsTemplate.convertAndSend(sendQueue, msg);
+        myNonJmsTemplate106.convertAndSend(sendQueue, msg);
     }
 }
 

--- a/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level107/MQConfiguration107.java
+++ b/Spring-JMS/src/main/java/com/ibm/mq/samples/jms/spring/level107/MQConfiguration107.java
@@ -35,7 +35,7 @@ public class MQConfiguration107 {
     private ConnectionFactory connectionFactory;
 
     @Bean("myNonJmsTemplate107")
-    public JmsTemplate myNonJmsTemplate() {
+    public JmsTemplate myNonJmsTemplate107() {
         JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
         jmsTemplate.setDestinationResolver(new OurDestinationResolver());
         jmsTemplate.setMessageConverter(new OurMessageConverter());


### PR DESCRIPTION
Level 101 uses the default out of the box template, which is ok when it is the only component in use, but this conflicted with  templates defined by the other samples.