### PR TITLE
Enable Cors in Serverless CodeEngine App

### DIFF
--- a/serverless/codeengine/clientapp/mqapp.js
+++ b/serverless/codeengine/clientapp/mqapp.js
@@ -23,7 +23,7 @@ const pug = require('pug');
 const path = require('path');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');
-var cors = require('cors');
+const cors = require('cors');
 
 const app = express();
 app.use(cors());

--- a/serverless/codeengine/clientapp/mqapp.js
+++ b/serverless/codeengine/clientapp/mqapp.js
@@ -23,8 +23,10 @@ const pug = require('pug');
 const path = require('path');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');
+var cors = require('cors');
 
 const app = express();
+app.use(cors());
 app.use(logger(process.env.REQUEST_LOG_FORMAT || 'dev'));
 
 

--- a/serverless/codeengine/clientapp/package.json
+++ b/serverless/codeengine/clientapp/package.json
@@ -3,31 +3,26 @@
   "name": "sample",
   "version": "0.0.1",
   "description": "Sample Code Engine, Serverless, Node.js MQ Client app",
-
   "main": "server.js",
   "license": "Apache-2.0",
-
   "repository": {
     "type": "git",
     "url": "https://github.com/ibm-messaging/mq-dev-patterns"
   },
-
   "dependencies": {
-    "ibmmq": "^0.9.19",
+    "cookie-parser": "~1.4.4",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
-    "pug": "^3.0.2",
-    "morgan": "~1.9.1",
     "http-errors": "~1.8.0",
-    "cookie-parser": "~1.4.4"
+    "ibmmq": "^0.9.19",
+    "morgan": "~1.9.1",
+    "pug": "^3.0.2"
   },
-
   "scripts": {
     "start": "DEBUG=mqapp* node server.js"
   },
-
-  "engines" : {
+  "engines": {
     "node": ">=12.16.3"
   },
-
   "type": "commonjs"
 }


### PR DESCRIPTION
Browser side web frameworks, like reactjs, require CORS to be enabled.