### PR TITLE
Update TLS instructions for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Also, if you have two docker containers, one with TLS and one without, changing 
 ### Apple Silicon
 
 The IBM MQ Client Toolkit on Apple Silicon (ARM64) makes use of OpenSSL libraries
-for TLS. For the MQI based samples in this repository, This means that
+for TLS. For the MQI based samples in this repository, this means that
 `KEY_REPOSITORY` in the `env.json` file or environment
 variable `KEY_REPOSITORY` be set to the path for the queue manager's exported `.pem` file. eg. If you have exported the `qmgrcert.pem` file to the root directory of this repository, then set `KEY_REPOSITORY` to `../qmgrcert.pem` .
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can use your own MQ server, you'll just have to adjust the MQ objects accord
 * **MODEL_QUEUE_NAME** - Model Queue used as template to base dynamic queues on for `request/response`
 * **DYNAMIC_QUEUE_PREFIX** - Prefix for dynamically created reply queue - you don't need to create this
 * **CIPHER_SPEC** - If present in the `env,json`, TLS Cipher specification to use
-* **KEY_REPOSITORY** - Path to the `keystore` `.kbd` and `.sth` files. If running on Apple Silicon then this will the full path to the queue manager's exported `trust.pem`. If present in the `env.json`, TLS is enabled - this is on the app side.
+* **KEY_REPOSITORY** - Path to the `keystore` `.kbd` and `.sth` files. If running on Apple Silicon then this will the path to the queue manager's exported `trust.pem`. If present in the `env.json`, TLS is enabled - this is on the app side.
 
 If instead you choose to provide a client channel definition table (CCDT) file,
 then the **Host**, **PORT**, **Channel** and **Cipher** are provided by the
@@ -103,9 +103,7 @@ Also, if you have two docker containers, one with TLS and one without, changing 
 The IBM MQ Client Toolkit on Apple Silicon (ARM64) makes use of OpenSSL libraries
 for TLS. For the MQI based samples in this repository, This means that
 `KEY_REPOSITORY` in the `env.json` file or environment
-variable `KEY_REPOSITORY` be set to the path for the queue manager's exported `trust.pem` file. eg. If you have exported the `.pem` file to the root directory of this repository, then set `KEY_REPOSITORY` to `../trust.pem` .
-
-**Note:** The file must be called `trust.pem`
+variable `KEY_REPOSITORY` be set to the path for the queue manager's exported `.pem` file. eg. If you have exported the `qmgrcert.pem` file to the root directory of this repository, then set `KEY_REPOSITORY` to `../qmgrcert.pem` .
 
 
 ### Running a second Docker container with TLS

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can use your own MQ server, you'll just have to adjust the MQ objects accord
 * **MODEL_QUEUE_NAME** - Model Queue used as template to base dynamic queues on for `request/response`
 * **DYNAMIC_QUEUE_PREFIX** - Prefix for dynamically created reply queue - you don't need to create this
 * **CIPHER_SPEC** - If present in the `env,json`, TLS Cipher specification to use
-* **KEY_REPOSITORY** - Path to the `keystore` `.kbd` and `.sth` files. If running on Apple Silicon then this will the path to the queue manager's exported `trust.pem`. If present in the `env.json`, TLS is enabled - this is on the app side.
+* **KEY_REPOSITORY** - Path to the `keystore` `.kbd` and `.sth` files. If running on Apple Silicon then this will the path to the queue manager's exported `.pem`. If present in the `env.json`, TLS is enabled - this is on the app side.
 
 If instead you choose to provide a client channel definition table (CCDT) file,
 then the **Host**, **PORT**, **Channel** and **Cipher** are provided by the

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can use your own MQ server, you'll just have to adjust the MQ objects accord
 * **MODEL_QUEUE_NAME** - Model Queue used as template to base dynamic queues on for `request/response`
 * **DYNAMIC_QUEUE_PREFIX** - Prefix for dynamically created reply queue - you don't need to create this
 * **CIPHER_SPEC** - If present in the `env,json`, TLS Cipher specification to use
-* **KEY_REPOSITORY** - Path to the `keystore` `.kbd` and `.sth` files. If present in the `env.json`, TLS is enabled - this is on the app side.
+* **KEY_REPOSITORY** - Path to the `keystore` `.kbd` and `.sth` files. If running on Apple Silicon then this will the full path to the queue manager's exported `trust.pem`. If present in the `env.json`, TLS is enabled - this is on the app side.
 
 If instead you choose to provide a client channel definition table (CCDT) file,
 then the **Host**, **PORT**, **Channel** and **Cipher** are provided by the
@@ -98,6 +98,16 @@ will mean the sample will not connect using TLS.
 
 Also, if you have two docker containers, one with TLS and one without, changing the port number in the `env.json` allows you to switch between them.
 
+### Apple Silicon
+
+The IBM MQ Client Toolkit on Apple Silicon (ARM64) makes use of OpenSSL libraries
+for TLS. For the MQI based samples in this repository, This means that
+`KEY_REPOSITORY` in the `env.json` file or environment
+variable `KEY_REPOSITORY` be set to the path for the queue manager's exported `trust.pem` file. eg. If you have exported the `.pem` file to the root directory of this repository, then set `KEY_REPOSITORY` to `../trust.pem` .
+
+**Note:** The file must be called `trust.pem`
+
+
 ### Running a second Docker container with TLS
 
 Let's say you're already running MQ in a Docker container without TLS having set it up by following the [Ready, Set, Connect](https://developer.ibm.com/messaging/learn-mq/mq-tutorials/mq-connect-to-queue-manager/) tutorial.
@@ -167,24 +177,24 @@ then run
 to start the container again.
 
 ## MQI Paths
-The MQI samples; `Node.js`, `Python`, `Go`, require the MQI Client to have been
+The MQI samples; `Node.js`, `Python`, `Go`, require the MQI Client Toolkit to have been
 installed and the paths
 
 `MQ_INSTALLATION_PATH` and
 
-`DYLD_LIBRARY_PATH` set.
+`DYLD_LIBRARY_PATH` (MacOS) or `LD_LIBRARY_PATH` (Windows or Linux) set.
 
 If you have installed the MQI client manually, ensure that
 
 `MQ_INSTALLATION_PATH` is set to the root directory of your MQI Client installation and
 
-`DYLD_LIBRARY_PATH` is set to `$MQ_INSTALLATION_PATH\lib64`.
+`DYLD_LIBRARY_PATH` or `LD_LIBRARY_PATH` is set to `$MQ_INSTALLATION_PATH\lib64`.
 
 Do not install any application requirements until
 
 `MQ_INSTALLATION_PATH` and
 
-`DYLD_LIBRARY_PATH` are set and exported (see language README docs for more info).
+`DYLD_LIBRARY_PATH` or `LD_LIBRARY_PATH` are set and exported (see language README docs for more info).
 
 ## README docs
 


### PR DESCRIPTION
Clarify how to set TLS when using the MQI patterns in the repository running on MacOS ARM64 machines.