### PR TITLE
Optional noauth in bindings mode

### DIFF
--- a/JMS/com/ibm/mq/samples/jms/ConnectionHelper.java
+++ b/JMS/com/ibm/mq/samples/jms/ConnectionHelper.java
@@ -155,9 +155,13 @@ public class ConnectionHelper {
 
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
             cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, id);
-            cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
-            cf.setStringProperty(WMQConstants.USERID, APP_USER);
-            cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            
+            if (null != APP_USER && !APP_USER.trim().isEmpty()) {
+                cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+                cf.setStringProperty(WMQConstants.USERID, APP_USER);
+                cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            }
+
             if (CIPHER_SUITE != null && !CIPHER_SUITE.isEmpty()) {
                 cf.setStringProperty(WMQConstants.WMQ_SSL_CIPHER_SUITE, CIPHER_SUITE);
             }

--- a/JMS/com/ibm/mq/samples/jms/JmsGet.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsGet.java
@@ -198,9 +198,11 @@ public class JmsGet {
             
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
             cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "JmsGet (JMS)");
-            cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
-            cf.setStringProperty(WMQConstants.USERID, APP_USER);
-            cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            if (null != APP_USER && !APP_USER.trim().isEmpty()) {
+                cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+                cf.setStringProperty(WMQConstants.USERID, APP_USER);
+                cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            }
             if (CIPHER_SUITE != null && !CIPHER_SUITE.isEmpty()) {
                 cf.setStringProperty(WMQConstants.WMQ_SSL_CIPHER_SUITE, CIPHER_SUITE);
             }

--- a/JMS/com/ibm/mq/samples/jms/JmsPub.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsPub.java
@@ -143,9 +143,11 @@ public class JmsPub {
 
       cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
       cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "SimplePub (JMS)");
-      cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
-      cf.setStringProperty(WMQConstants.USERID, APP_USER);
-      cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+      if (null != APP_USER && !APP_USER.trim().isEmpty()) {
+        cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+        cf.setStringProperty(WMQConstants.USERID, APP_USER);
+        cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+      }
       cf.setStringProperty(WMQConstants.CLIENT_ID, PUBLICATION_NAME);
       if (CIPHER_SUITE != null && !CIPHER_SUITE.isEmpty()) {
         cf.setStringProperty(WMQConstants.WMQ_SSL_CIPHER_SUITE, CIPHER_SUITE);

--- a/JMS/com/ibm/mq/samples/jms/JmsPut.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsPut.java
@@ -135,9 +135,11 @@ public class JmsPut {
 
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
             cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "JmsPut (JMS)");
-            cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
-            cf.setStringProperty(WMQConstants.USERID, APP_USER);
-            cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            if (null != APP_USER && !APP_USER.trim().isEmpty()) {
+                cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+                cf.setStringProperty(WMQConstants.USERID, APP_USER);
+                cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            }
             if (CIPHER_SUITE != null && !CIPHER_SUITE.isEmpty()) {
                 cf.setStringProperty(WMQConstants.WMQ_SSL_CIPHER_SUITE, CIPHER_SUITE);
             }

--- a/JMS/com/ibm/mq/samples/jms/JmsRequest.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsRequest.java
@@ -190,9 +190,11 @@ public class JmsRequest {
 
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
             cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "JmsRequest");
-            cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
-            cf.setStringProperty(WMQConstants.USERID, APP_USER);
-            cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            if (null != APP_USER && !APP_USER.trim().isEmpty()) {
+                cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+                cf.setStringProperty(WMQConstants.USERID, APP_USER);
+                cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            }
             cf.setStringProperty(WMQConstants.WMQ_TEMPORARY_MODEL, MODEL_QUEUE_NAME);
             if (CIPHER_SUITE != null && !CIPHER_SUITE.isEmpty()) {
                 cf.setStringProperty(WMQConstants.WMQ_SSL_CIPHER_SUITE, CIPHER_SUITE);

--- a/JMS/com/ibm/mq/samples/jms/JmsResponse.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsResponse.java
@@ -272,9 +272,11 @@ public class JmsResponse {
 
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
             cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "JmsBasicResponse (JMS)");
-            cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
-            cf.setStringProperty(WMQConstants.USERID, APP_USER);
-            cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            if (null != APP_USER && !APP_USER.trim().isEmpty()) {
+                cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+                cf.setStringProperty(WMQConstants.USERID, APP_USER);
+                cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            }
             if (CIPHER_SUITE != null && !CIPHER_SUITE.isEmpty()) {
                 cf.setStringProperty(WMQConstants.WMQ_SSL_CIPHER_SUITE, CIPHER_SUITE);
             }

--- a/JMS/com/ibm/mq/samples/jms/JmsSub.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsSub.java
@@ -145,9 +145,11 @@ public class JmsSub {
             
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
             cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "SimpleSub (JMS)");
-            cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
-            cf.setStringProperty(WMQConstants.USERID, APP_USER);
-            cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            if (null != APP_USER && !APP_USER.trim().isEmpty()) {
+                cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+                cf.setStringProperty(WMQConstants.USERID, APP_USER);
+                cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
+            }
             cf.setStringProperty(WMQConstants.CLIENT_ID, SUBSCRIPTION_NAME);
             if (CIPHER_SUITE != null && !CIPHER_SUITE.isEmpty()) {
                 cf.setStringProperty(WMQConstants.WMQ_SSL_CIPHER_SUITE, CIPHER_SUITE);


### PR DESCRIPTION
If userid is not provided in the env.json nor environment, then don't set in connection to allow bindings / no auth runtimes.