### PR TITLE
Attributes for Z

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,39 @@
 # file encodings for zOS
-*.java zos-working-tree-encoding=ibm-1047
+# When cloning onto Z/OS convert the source files into ibm-1047 US EBCDIC
+
+# Documentation
+*.md zos-working-tree-encoding=ibm-1047
+
+# Configuration files
 *.json zos-working-tree-encoding=ibm-1047
+*.properties zos-working-tree-encoding=ibm-1047
+*.xml zos-working-tree-encoding=ibm-1047
+
+# C# source files
+*.cs zos-working-tree-encoding=ibm-1047
+
+# Go source files
+*.go zos-working-tree-encoding=ibm-1047
+*.mod zos-working-tree-encoding=ibm-1047
+*.sum zos-working-tree-encoding=ibm-1047
+
+# Java source files
+*.java zos-working-tree-encoding=ibm-1047
+
+# Node source files
+*.js zos-working-tree-encoding=ibm-1047
+
+# Python source files
+*.py zos-working-tree-encoding=ibm-1047
+
+# Rust source files
+*.rs zos-working-tree-encoding=ibm-1047
+*.toml zos-working-tree-encoding=ibm-1047
+
+# Shell scripts
+*.sh zos-working-tree-encoding=ibm-1047
+
+# Swift scripts
+*.swift zos-working-tree-encoding=ibm-1047
+# not .xcodeproj  ?
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# file encodings for zOS
+*.java zos-working-tree-encoding=ibm-1047
+*.json zos-working-tree-encoding=ibm-1047

--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,8 @@
 
 # Node source files
 *.js zos-working-tree-encoding=ibm-1047
+# Always use LF for npm package files because npm cli likes to change line endings.
+package*.json text eol=lf
 
 # Python source files
 *.py zos-working-tree-encoding=ibm-1047


### PR DESCRIPTION
Added .gitattributes file to allow code source files to be correctly converted from UTF to EBCDIC when the repository is cloned onto Z systems.