### PR TITLE
Fix promise resolution in getMessages

### DIFF
--- a/Node.js/basicget.js
+++ b/Node.js/basicget.js
@@ -237,6 +237,8 @@ function getMessage(hObj) {
   });
 }
 
+// getMessages promise only resolves if there are either no more messages
+// or it is not possible to retrieve any more messages.
 function getMessages(hObj) {
   return new Promise(function resolver(resolve, reject) {
     debug_info('Retrieving next messages in getMessages');
@@ -249,8 +251,6 @@ function getMessages(hObj) {
         resolve();
       }
     })
-
-    resolve();
   });
 }
 

--- a/Node.js/basicget.js
+++ b/Node.js/basicget.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, 2019 IBM Corp.
+ * Copyright 2018, 2023 IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The getMessages promise should only resolve if there are no new messages or it is not possible to retrieve more messages.