### PR TITLE
Code fixes to enable connection to a uniform cluster

### DIFF
--- a/JMS/com/ibm/mq/samples/jms/ConnectionHelper.java
+++ b/JMS/com/ibm/mq/samples/jms/ConnectionHelper.java
@@ -173,6 +173,10 @@ public class ConnectionHelper {
             } else {
                 logger.info("Will be making use of CCDT File " + CCDTURL);
                 cf.setStringProperty(WMQConstants.WMQ_CCDTURL, CCDTURL);
+
+                // Set the WMQ_CLIENT_RECONNECT_OPTIONS property to allow 
+                // the MQ JMS classes to attempt a reconnect 
+                // cf.setIntProperty(WMQConstants.WMQ_CLIENT_RECONNECT_OPTIONS, WMQConstants.WMQ_CLIENT_RECONNECT);
             }
 
             if (BINDINGS) {

--- a/JMS/com/ibm/mq/samples/jms/ConnectionHelper.java
+++ b/JMS/com/ibm/mq/samples/jms/ConnectionHelper.java
@@ -47,7 +47,6 @@ public class ConnectionHelper {
     private static final Level LOGLEVEL = Level.ALL;
     private static final Logger logger = Logger.getLogger("com.ibm.mq.samples.jms");
     public static final int USE_CONNECTION_STRING = -1;
-    private static final int DEFAULT_MQI_PORT = 1414;
 
     // Create variables for the connection to MQ
     private static String ConnectionString = null; //= "localhost(1414),localhost(1416)"
@@ -122,14 +121,7 @@ public class ConnectionHelper {
                 index = 0;
             } else {
                 HOST = env.getEnvValue("HOST", index);
-                try {
-                    PORT = Integer.parseInt(env.getEnvValue("PORT", index));
-                } catch (NumberFormatException e) {
-                    logger.warning("Unable to parse a number for port ");
-                    logger.warning("CCDT has not been specified, defaulting port to " + DEFAULT_MQI_PORT);
-                    PORT = DEFAULT_MQI_PORT;
-                } 
-                
+                PORT = env.getPortEnvValue("PORT", index);                
                 logger.info("Connection to " + HOST + "(" + PORT + ")");
             }
         } else if (USE_CONNECTION_STRING == index) {
@@ -177,8 +169,7 @@ public class ConnectionHelper {
                     logger.warning("When running in client mode, either channel or CCDT must be provided");
                 } else if (null != CHANNEL) {
                     cf.setStringProperty(WMQConstants.WMQ_CHANNEL, CHANNEL);
-                }
-                
+                }         
             } else {
                 logger.info("Will be making use of CCDT File " + CCDTURL);
                 cf.setStringProperty(WMQConstants.WMQ_CCDTURL, CCDTURL);

--- a/JMS/com/ibm/mq/samples/jms/JmsGet.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsGet.java
@@ -163,9 +163,19 @@ public class JmsGet {
     }
 
     private static void mqConnectionVariables(SampleEnvSetter env, int index) {
-        HOST = env.getEnvValue("HOST", index);
-        logger.info(HOST);
-        PORT = Integer.parseInt(env.getEnvValue("PORT", index));
+        CCDTURL = env.getCheckForCCDT();
+
+        // If there is a CCDT then Host and Port will be 
+        // specified there
+        if (null == CCDTURL) {
+            HOST = env.getEnvValue("HOST", index);
+            try {
+                PORT = Integer.parseInt(env.getEnvValue("PORT", index));
+            } catch (NumberFormatException e) {
+                logger.warning("Unable to parse a number for port ");
+            } 
+        }
+    
         CHANNEL = env.getEnvValue("CHANNEL", index);
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
@@ -173,10 +183,6 @@ public class JmsGet {
         QUEUE_NAME = env.getEnvValue("QUEUE_NAME", index);
         CIPHER_SUITE = env.getEnvValue("CIPHER_SUITE", index);
         BINDINGS = env.getEnvBooleanValue("BINDINGS", index);
-
-        if (null == CCDTURL) {
-          CCDTURL = env.getCheckForCCDT();
-        }
     }
 
     private static JmsConnectionFactory createJMSConnectionFactory() {

--- a/JMS/com/ibm/mq/samples/jms/JmsGet.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsGet.java
@@ -169,11 +169,7 @@ public class JmsGet {
         // specified there
         if (null == CCDTURL) {
             HOST = env.getEnvValue("HOST", index);
-            try {
-                PORT = Integer.parseInt(env.getEnvValue("PORT", index));
-            } catch (NumberFormatException e) {
-                logger.warning("Unable to parse a number for port ");
-            } 
+            PORT = env.getPortEnvValue("PORT", index);
         }
     
         CHANNEL = env.getEnvValue("CHANNEL", index);

--- a/JMS/com/ibm/mq/samples/jms/JmsGet.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsGet.java
@@ -211,6 +211,10 @@ public class JmsGet {
             } else {
                 logger.info("Will be making use of CCDT File " + CCDTURL);
                 cf.setStringProperty(WMQConstants.WMQ_CCDTURL, CCDTURL);
+                
+                // Set the WMQ_CLIENT_RECONNECT_OPTIONS property to allow 
+                // the MQ JMS classes to attempt a reconnect 
+                // cf.setIntProperty(WMQConstants.WMQ_CLIENT_RECONNECT_OPTIONS, WMQConstants.WMQ_CLIENT_RECONNECT);
             }
 
             if (BINDINGS) {

--- a/JMS/com/ibm/mq/samples/jms/JmsPub.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsPub.java
@@ -116,7 +116,14 @@ public class JmsPub {
     SampleEnvSetter env = new SampleEnvSetter();
     int index = 0;
 
-    ConnectionString = env.getConnectionString();
+    CCDTURL = env.getCheckForCCDT();
+
+    // If the CCDT is in use then a connection string will 
+    // not be needed.
+    if (null == CCDTURL) {
+        ConnectionString = env.getConnectionString();
+    }
+
     CHANNEL = env.getEnvValue("CHANNEL", index);
     QMGR = env.getEnvValue("QMGR", index);
     APP_USER = env.getEnvValue("APP_USER", index);
@@ -124,8 +131,6 @@ public class JmsPub {
     TOPIC_NAME = env.getEnvValue("TOPIC_NAME", index);
     CIPHER_SUITE = env.getEnvValue("CIPHER_SUITE", index);
     BINDINGS = env.getEnvBooleanValue("BINDINGS", index);
-
-    CCDTURL = env.getCheckForCCDT();
   }
 
   private static JmsConnectionFactory createJMSConnectionFactory() {

--- a/JMS/com/ibm/mq/samples/jms/JmsPub.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsPub.java
@@ -162,6 +162,10 @@ public class JmsPub {
       } else {
           logger.info("Will be making use of CCDT File " + CCDTURL);
           cf.setStringProperty(WMQConstants.WMQ_CCDTURL, CCDTURL);
+    
+          // Set the WMQ_CLIENT_RECONNECT_OPTIONS property to allow 
+          // the MQ JMS classes to attempt a reconnect 
+          // cf.setIntProperty(WMQConstants.WMQ_CLIENT_RECONNECT_OPTIONS, WMQConstants.WMQ_CLIENT_RECONNECT);
       }
 
       if (BINDINGS) {

--- a/JMS/com/ibm/mq/samples/jms/JmsPut.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsPut.java
@@ -153,6 +153,10 @@ public class JmsPut {
             } else {
                 logger.info("Will be making use of CCDT File " + CCDTURL);
                 cf.setStringProperty(WMQConstants.WMQ_CCDTURL, CCDTURL);
+                
+                // Set the WMQ_CLIENT_RECONNECT_OPTIONS property to allow 
+                // the MQ JMS classes to attempt a reconnect 
+                // cf.setIntProperty(WMQConstants.WMQ_CLIENT_RECONNECT_OPTIONS, WMQConstants.WMQ_CLIENT_RECONNECT);
             }
 
             if (BINDINGS) {

--- a/JMS/com/ibm/mq/samples/jms/JmsPut.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsPut.java
@@ -107,7 +107,14 @@ public class JmsPut {
         SampleEnvSetter env = new SampleEnvSetter();
         int index = 0;
 
-        ConnectionString = env.getConnectionString();
+        CCDTURL = env.getCheckForCCDT();
+
+        // If the CCDT is in use then a connection string will 
+        // not be needed.
+        if (null == CCDTURL) {
+            ConnectionString = env.getConnectionString();
+        }
+
         CHANNEL = env.getEnvValue("CHANNEL", index);
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
@@ -115,8 +122,6 @@ public class JmsPut {
         QUEUE_NAME = env.getEnvValue("QUEUE_NAME", index);
         CIPHER_SUITE = env.getEnvValue("CIPHER_SUITE", index);
         BINDINGS = env.getEnvBooleanValue("BINDINGS", index);
-
-        CCDTURL = env.getCheckForCCDT();
     }
 
     private static JmsConnectionFactory createJMSConnectionFactory() {

--- a/JMS/com/ibm/mq/samples/jms/JmsRequest.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsRequest.java
@@ -272,6 +272,10 @@ public class JmsRequest {
             } else {
                 logger.info("Will be making use of CCDT File " + CCDTURL);
                 cf.setStringProperty(WMQConstants.WMQ_CCDTURL, CCDTURL);
+    
+                // Set the WMQ_CLIENT_RECONNECT_OPTIONS property to allow 
+                // the MQ JMS classes to attempt a reconnect 
+                // cf.setIntProperty(WMQConstants.WMQ_CLIENT_RECONNECT_OPTIONS, WMQConstants.WMQ_CLIENT_RECONNECT);
             }
 
             if (BINDINGS) {

--- a/JMS/com/ibm/mq/samples/jms/JmsRequest.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsRequest.java
@@ -212,7 +212,14 @@ public class JmsRequest {
         SampleEnvSetter env = new SampleEnvSetter();
         int index = 0;
 
-        ConnectionString = env.getConnectionString();
+        CCDTURL = env.getCheckForCCDT();
+
+        // If the CCDT is in use then a connection string will 
+        // not be needed.
+        if (null == CCDTURL) {
+            ConnectionString = env.getConnectionString();
+        }
+
         CHANNEL = env.getEnvValue("CHANNEL", index);
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
@@ -234,8 +241,6 @@ public class JmsRequest {
         } else {
             REQUEST_MESSAGE_EXPIRY = 900000L;
         }
-
-        CCDTURL = env.getCheckForCCDT();
     }
 
     private static JmsConnectionFactory createJMSConnectionFactory() {

--- a/JMS/com/ibm/mq/samples/jms/JmsResponse.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsResponse.java
@@ -303,7 +303,15 @@ public class JmsResponse {
     private static void mqConnectionVariables() {
         SampleEnvSetter env = new SampleEnvSetter();
         int index = 0;
-        ConnectionString = env.getConnectionString();
+
+        CCDTURL = env.getCheckForCCDT();
+
+        // If the CCDT is in use then a connection string will 
+        // not be needed.
+        if (null == CCDTURL) {
+            ConnectionString = env.getConnectionString();
+        }
+
         CHANNEL = env.getEnvValue("CHANNEL", index);
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
@@ -323,8 +331,6 @@ public class JmsResponse {
         if ( BACKOUT_QUEUE == null || BACKOUT_QUEUE.isEmpty() ) { 
             logger.info("Missing BACKOUT_QUEUE value"); 
         }
-
-        CCDTURL = env.getCheckForCCDT();
     }
 
     private static JmsConnectionFactory createJMSConnectionFactory() {

--- a/JMS/com/ibm/mq/samples/jms/JmsResponse.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsResponse.java
@@ -364,6 +364,10 @@ public class JmsResponse {
             } else {
                 logger.info("Will be making use of CCDT File " + CCDTURL);
                 cf.setStringProperty(WMQConstants.WMQ_CCDTURL, CCDTURL);
+
+                // Set the WMQ_CLIENT_RECONNECT_OPTIONS property to allow 
+                // the MQ JMS classes to attempt a reconnect 
+                // cf.setIntProperty(WMQConstants.WMQ_CLIENT_RECONNECT_OPTIONS, WMQConstants.WMQ_CLIENT_RECONNECT);
             }
 
             if (BINDINGS) {

--- a/JMS/com/ibm/mq/samples/jms/JmsSub.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsSub.java
@@ -163,6 +163,10 @@ public class JmsSub {
             } else {
                 logger.info("Will be making use of CCDT File " + CCDTURL);
                 cf.setStringProperty(WMQConstants.WMQ_CCDTURL, CCDTURL);
+
+                // Set the WMQ_CLIENT_RECONNECT_OPTIONS property to allow 
+                // the MQ JMS classes to attempt a reconnect 
+                // cf.setIntProperty(WMQConstants.WMQ_CLIENT_RECONNECT_OPTIONS, WMQConstants.WMQ_CLIENT_RECONNECT);
             }
                   
             if (BINDINGS) {

--- a/JMS/com/ibm/mq/samples/jms/JmsSub.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsSub.java
@@ -117,7 +117,14 @@ public class JmsSub {
         SampleEnvSetter env = new SampleEnvSetter();
         int index = 0;
 
-        ConnectionString = env.getConnectionString();
+        CCDTURL = env.getCheckForCCDT();
+
+        // If the CCDT is in use then a connection string will 
+        // not be needed.
+        if (null == CCDTURL) {
+            ConnectionString = env.getConnectionString();
+        }
+
         CHANNEL = env.getEnvValue("CHANNEL", index);
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
@@ -125,8 +132,6 @@ public class JmsSub {
         TOPIC_NAME = env.getEnvValue("TOPIC_NAME", index);
         CIPHER_SUITE = env.getEnvValue("CIPHER_SUITE", index);
         BINDINGS = env.getEnvBooleanValue("BINDINGS", index);
-
-        CCDTURL = env.getCheckForCCDT();
     }
 
     private static JmsConnectionFactory createJMSConnectionFactory() {

--- a/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
+++ b/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
@@ -170,8 +170,9 @@ public class SampleEnvSetter {
 
                 File tmp = new File(ccdtFile);
                 if (! tmp.exists()) {
+                    logger.info("CCDT file not found");
                     value = null;
-                }
+                } 
             }
         }
         return value;

--- a/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
+++ b/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
@@ -120,7 +120,6 @@ public class SampleEnvSetter {
         } catch (NumberFormatException e) {
             logger.warning("Unable to parse a number for port ");
             logger.warning("defaulting port to " + DEFAULT_MQI_PORT);
-            value = DEFAULT_MQI_PORT;
         } 
         return value;
     }

--- a/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
+++ b/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
@@ -36,6 +36,7 @@ public class SampleEnvSetter {
     private static final String CCDT = "MQCCDTURL";
     private static final String FILEPREFIX = "file://";
     private static final String ZOS = "z/os";
+    private static final int DEFAULT_MQI_PORT = 1414;
 
     public SampleEnvSetter() {
         JSONObject mqEnvSettings = null;
@@ -109,6 +110,18 @@ public class SampleEnvSetter {
         if (! key.contains("PASSWORD")) {
           logger.info("returning " + value + " for key " + key);
         }
+        return value;
+    }
+
+    public int getPortEnvValue(String key, int index) {
+        int value = DEFAULT_MQI_PORT;
+        try {
+            value = Integer.parseInt(this.getEnvValue(key, index));
+        } catch (NumberFormatException e) {
+            logger.warning("Unable to parse a number for port ");
+            logger.warning("defaulting port to " + DEFAULT_MQI_PORT);
+            value = DEFAULT_MQI_PORT;
+        } 
         return value;
     }
 

--- a/JMS/pom.xml
+++ b/JMS/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
         <groupId>com.ibm.mq</groupId>
         <artifactId>com.ibm.mq.allclient</artifactId>
-        <version>9.2.5.0</version>
+        <version>9.3.4.0</version>
     </dependency>
     <dependency>
         <groupId>org.json</groupId>


### PR DESCRIPTION
Fix code issues when host and port are not provided in the environment values. These are not needed when a CCDT is in use.