### PR TITLE
Allow application name to be set via environment settings 

### DIFF
--- a/JMS/com/ibm/mq/samples/jms/ConnectionHelper.java
+++ b/JMS/com/ibm/mq/samples/jms/ConnectionHelper.java
@@ -56,6 +56,7 @@ public class ConnectionHelper {
     private String QMGR = null; // Queue manager name
     private String APP_USER = null; // User name that application uses to connect to MQ
     private String APP_PASSWORD = null; // Password that the application uses to connect to MQ
+    private String APP_NAME = null; // Application Name that the application uses
     private String QUEUE_NAME = null; // Queue that the application uses to put and get messages to and from
     private String TOPIC_NAME = null; // Topic that the application publishes to
     private String CIPHER_SUITE = null;
@@ -67,7 +68,7 @@ public class ConnectionHelper {
     public ConnectionHelper (String id, int index) {
 
         //initialiseLogging();
-        mqConnectionVariables(index);
+        mqConnectionVariables(id, index);
         logger.info("Get application is starting");
 
         JmsConnectionFactory connectionFactory = createJMSConnectionFactory();
@@ -107,7 +108,7 @@ public class ConnectionHelper {
       }
     }
 
-    private void mqConnectionVariables(int index) {
+    private void mqConnectionVariables(String default_app_name, int index) {
         SampleEnvSetter env = new SampleEnvSetter();
 
         CCDTURL = env.getCheckForCCDT();
@@ -132,6 +133,7 @@ public class ConnectionHelper {
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
         APP_PASSWORD = env.getEnvValue("APP_PASSWORD", index);
+        APP_NAME = env.getEnvValueOrDefault("APP_NAME", default_app_name, index);
         QUEUE_NAME = env.getEnvValue("QUEUE_NAME", index);
         TOPIC_NAME = env.getEnvValue("TOPIC_NAME", index);
         CIPHER_SUITE = env.getEnvValue("CIPHER_SUITE", index);

--- a/JMS/com/ibm/mq/samples/jms/JmsGet.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsGet.java
@@ -52,6 +52,7 @@ import com.ibm.mq.samples.jms.SampleEnvSetter;
 
 public class JmsGet {
 
+    private static final String DEFAULT_APP_NAME = "Dev Experience JmsGet";
     private static final Level LOGLEVEL = Level.ALL;
     private static final Logger logger = Logger.getLogger("com.ibm.mq.samples.jms");
 
@@ -62,6 +63,7 @@ public class JmsGet {
     private static String QMGR; // Queue manager name
     private static String APP_USER; // User name that application uses to connect to MQ
     private static String APP_PASSWORD; // Password that the application uses to connect to MQ
+    private static String APP_NAME; // Application Name that the application uses
     private static String QUEUE_NAME; // Queue that the application uses to put and get messages to and from
     private static String CIPHER_SUITE;
     private static String CCDTURL;
@@ -176,6 +178,7 @@ public class JmsGet {
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
         APP_PASSWORD = env.getEnvValue("APP_PASSWORD", index);
+        APP_NAME = env.getEnvValueOrDefault("APP_NAME", DEFAULT_APP_NAME, index);
         QUEUE_NAME = env.getEnvValue("QUEUE_NAME", index);
         CIPHER_SUITE = env.getEnvValue("CIPHER_SUITE", index);
         BINDINGS = env.getEnvBooleanValue("BINDINGS", index);
@@ -224,7 +227,7 @@ public class JmsGet {
             }
             
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
-            cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "JmsGet (JMS)");
+            cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, APP_NAME);
             if (null != APP_USER && !APP_USER.trim().isEmpty()) {
                 cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
                 cf.setStringProperty(WMQConstants.USERID, APP_USER);

--- a/JMS/com/ibm/mq/samples/jms/JmsPub.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsPub.java
@@ -51,6 +51,8 @@ import com.ibm.mq.jms.MQDestination;
 import com.ibm.mq.samples.jms.SampleEnvSetter;
 
 public class JmsPub {
+  private static final String DEFAULT_APP_NAME = "Dev Experience JmsPub";
+
   private static final Level LOGLEVEL = Level.ALL;
   private static final Logger logger = Logger.getLogger("com.ibm.mq.samples.jms");
 
@@ -60,6 +62,7 @@ public class JmsPub {
   private static String QMGR; // Queue manager name
   private static String APP_USER; // User name that application uses to connect to MQ
   private static String APP_PASSWORD; // Password that the application uses to connect to MQ
+  private static String APP_NAME; // Application Name that the application uses
   private static String TOPIC_NAME; // Topic that the application publishes to
   private static String PUBLICATION_NAME = "JmsPub - SamplePublisher"; //
   private static String CIPHER_SUITE;
@@ -128,6 +131,7 @@ public class JmsPub {
     QMGR = env.getEnvValue("QMGR", index);
     APP_USER = env.getEnvValue("APP_USER", index);
     APP_PASSWORD = env.getEnvValue("APP_PASSWORD", index);
+    APP_NAME = env.getEnvValueOrDefault("APP_NAME", DEFAULT_APP_NAME, index);
     TOPIC_NAME = env.getEnvValue("TOPIC_NAME", index);
     CIPHER_SUITE = env.getEnvValue("CIPHER_SUITE", index);
     BINDINGS = env.getEnvBooleanValue("BINDINGS", index);
@@ -175,7 +179,7 @@ public class JmsPub {
       }
 
       cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
-      cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "SimplePub (JMS)");
+      cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, APP_NAME);
       if (null != APP_USER && !APP_USER.trim().isEmpty()) {
         cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
         cf.setStringProperty(WMQConstants.USERID, APP_USER);

--- a/JMS/com/ibm/mq/samples/jms/JmsPut.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsPut.java
@@ -52,6 +52,7 @@ import com.ibm.mq.samples.jms.SampleEnvSetter;
 
 public class JmsPut {
 
+    private static final String DEFAULT_APP_NAME = "Dev Experience JmsPut";
     private static final Level LOGLEVEL = Level.ALL;
     private static final Logger logger = Logger.getLogger("com.ibm.mq.samples.jms");
 
@@ -61,6 +62,7 @@ public class JmsPut {
     private static String QMGR; // = "QM1"; //System.getenv("QMGR"); // Queue manager name
     private static String APP_USER; // = "app"; // User name that application uses to connect to MQ
     private static String APP_PASSWORD; // = "passw0rd"; // Password that the application uses to connect to MQ
+    private static String APP_NAME; // Application Name that the application uses
     private static String QUEUE_NAME; // = "DEV.QUEUE.1"; // Queue that the application uses to put and get messages
                                       // to and from
     private static String CIPHER_SUITE;
@@ -119,6 +121,7 @@ public class JmsPut {
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
         APP_PASSWORD = env.getEnvValue("APP_PASSWORD", index);
+        APP_NAME = env.getEnvValueOrDefault("APP_NAME", DEFAULT_APP_NAME, index);
         QUEUE_NAME = env.getEnvValue("QUEUE_NAME", index);
         CIPHER_SUITE = env.getEnvValue("CIPHER_SUITE", index);
         BINDINGS = env.getEnvBooleanValue("BINDINGS", index);
@@ -166,7 +169,7 @@ public class JmsPut {
             }
 
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
-            cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "JmsPut (JMS)");
+            cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, APP_NAME);
             if (null != APP_USER && !APP_USER.trim().isEmpty()) {
                 cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
                 cf.setStringProperty(WMQConstants.USERID, APP_USER);

--- a/JMS/com/ibm/mq/samples/jms/JmsRequest.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsRequest.java
@@ -60,6 +60,7 @@ import com.ibm.mq.samples.jms.SampleEnvSetter;
 
 public class JmsRequest {
 
+    private static final String DEFAULT_APP_NAME = "Dev Experience JmsRequest";
     private static final Level LOGLEVEL = Level.ALL;
     private static final Logger logger = Logger.getLogger("com.ibm.mq.samples.jms");
 
@@ -69,6 +70,7 @@ public class JmsRequest {
     private static String QMGR; // Queue manager name
     private static String APP_USER; // User name that application uses to connect to MQ
     private static String APP_PASSWORD; // Password that the application uses to connect to MQ
+    private static String APP_NAME; // Application Name that the application uses
     private static String QUEUE_NAME; // Queue that the application uses to put messages to
     private static String REPLY_QUEUE_NAME; // Queue that the application uses to get messages replies from
     private static String MODEL_QUEUE_NAME; //
@@ -224,6 +226,7 @@ public class JmsRequest {
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
         APP_PASSWORD = env.getEnvValue("APP_PASSWORD", index);
+        APP_NAME = env.getEnvValueOrDefault("APP_NAME", DEFAULT_APP_NAME, index);
         QUEUE_NAME = env.getEnvValue("QUEUE_NAME", index);
         REPLY_QUEUE_NAME = env.getEnvValue("REPLY_QUEUE_NAME", index);
         MODEL_QUEUE_NAME = env.getEnvValue("MODEL_QUEUE_NAME", index);
@@ -285,7 +288,7 @@ public class JmsRequest {
             }
 
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
-            cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "JmsRequest");
+            cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, APP_NAME);
             if (null != APP_USER && !APP_USER.trim().isEmpty()) {
                 cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
                 cf.setStringProperty(WMQConstants.USERID, APP_USER);

--- a/JMS/com/ibm/mq/samples/jms/JmsResponse.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsResponse.java
@@ -63,7 +63,7 @@ import com.ibm.mq.MQException;
 import com.ibm.mq.samples.jms.SampleEnvSetter;
 
 public class JmsResponse {
-
+    private static final String DEFAULT_APP_NAME = "Dev Experience JmsResponse";
     private static final Level LOGLEVEL = Level.ALL;
     private static final Logger logger = Logger.getLogger("com.ibm.mq.samples.jms");
 
@@ -73,6 +73,7 @@ public class JmsResponse {
     private static String QMGR; // Queue manager name
     private static String APP_USER; // User name that application uses to connect to MQ
     private static String APP_PASSWORD; // Password that the application uses to connect to MQ
+    private static String APP_NAME; // Application Name that the application uses
     private static String QUEUE_NAME; // Queue that the application uses to put and get messages to and from
     private static String CIPHER_SUITE;
     private static String CCDTURL;
@@ -316,6 +317,7 @@ public class JmsResponse {
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
         APP_PASSWORD = env.getEnvValue("APP_PASSWORD", index);
+        APP_NAME = env.getEnvValueOrDefault("APP_NAME", DEFAULT_APP_NAME, index);
         QUEUE_NAME = env.getEnvValue("QUEUE_NAME", index);
         CIPHER_SUITE = env.getEnvValue("CIPHER_SUITE", index);
         BINDINGS = env.getEnvBooleanValue("BINDINGS", index);
@@ -377,7 +379,7 @@ public class JmsResponse {
             }
 
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
-            cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "JmsBasicResponse (JMS)");
+            cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, APP_NAME);
             if (null != APP_USER && !APP_USER.trim().isEmpty()) {
                 cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
                 cf.setStringProperty(WMQConstants.USERID, APP_USER);

--- a/JMS/com/ibm/mq/samples/jms/JmsSub.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsSub.java
@@ -48,6 +48,7 @@ import com.ibm.msg.client.wmq.WMQConstants;
 import com.ibm.mq.samples.jms.SampleEnvSetter;
 
 public class JmsSub {
+    private static final String DEFAULT_APP_NAME = "Dev Experience JmsSub";
     private static final Level LOGLEVEL = Level.ALL;
     private static final Logger logger = Logger.getLogger("com.ibm.mq.samples.jms");
 
@@ -57,6 +58,7 @@ public class JmsSub {
     private static String QMGR; // Queue manager name
     private static String APP_USER; // User name that application uses to connect to MQ
     private static String APP_PASSWORD; // Password that the application uses to connect to MQ
+    private static String APP_NAME; // Application Name that the application uses
     private static String TOPIC_NAME; // Queue that the application uses to put and get messages to and from
     private static String SUBSCRIPTION_NAME = "JmsSub - SampleSubscriber";
     private static String CIPHER_SUITE;
@@ -129,6 +131,7 @@ public class JmsSub {
         QMGR = env.getEnvValue("QMGR", index);
         APP_USER = env.getEnvValue("APP_USER", index);
         APP_PASSWORD = env.getEnvValue("APP_PASSWORD", index);
+        APP_NAME = env.getEnvValueOrDefault("APP_NAME", DEFAULT_APP_NAME, index);
         TOPIC_NAME = env.getEnvValue("TOPIC_NAME", index);
         CIPHER_SUITE = env.getEnvValue("CIPHER_SUITE", index);
         BINDINGS = env.getEnvBooleanValue("BINDINGS", index);
@@ -176,7 +179,7 @@ public class JmsSub {
             }
             
             cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, QMGR);
-            cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "SimpleSub (JMS)");
+            cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, APP_NAME);
             if (null != APP_USER && !APP_USER.trim().isEmpty()) {
                 cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
                 cf.setStringProperty(WMQConstants.USERID, APP_USER);

--- a/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
+++ b/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
@@ -113,6 +113,14 @@ public class SampleEnvSetter {
         return value;
     }
 
+    public String getEnvValueOrDefault(String key, String defaultValue, int index) {
+        String value = getEnvValue(key, index);
+
+        return (null == value || value.trim().isEmpty()) 
+                        ? defaultValue
+                        : value;
+    }
+
     public int getPortEnvValue(String key, int index) {
         int value = DEFAULT_MQI_PORT;
         try {


### PR DESCRIPTION
Look at the environment value for `APP_NAME`, if present use it to set the connection factory property `WMQ_APPLICATIONNAME`. If not found then use a default.