### PR TITLE
Yield the CPU after a get

### DIFF
--- a/JMS/com/ibm/mq/samples/jms/BasicConsumer.java
+++ b/JMS/com/ibm/mq/samples/jms/BasicConsumer.java
@@ -95,13 +95,12 @@ public class BasicConsumer {
                    continueProcessing = false;
               } else {
                 new ConsumerHelper(receivedMessage);
+                logger.info("Waiting 1 second before looking for next message");
+                waitAWhile(1000);
               }
           } catch (JMSRuntimeException jmsex) {
               jmsex.printStackTrace();
-              try {
-                  Thread.sleep(1000);
-              } catch (InterruptedException e) {
-              }
+              waitAWhile(1000);
           }
        }
     }
@@ -111,5 +110,12 @@ public class BasicConsumer {
         ch.closeContext();
         consumer = null;
         ch = null;
+    }
+
+    private void waitAWhile(int duration) {
+        try {
+            Thread.sleep(duration);
+        } catch (InterruptedException e) {
+        }
     }
 }

--- a/JMS/com/ibm/mq/samples/jms/JmsGet.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsGet.java
@@ -138,13 +138,12 @@ public class JmsGet {
                      continueProcessing = false;
                 } else {
                   getAndDisplayMessageBody(receivedMessage);
+                  logger.info("Waiting 1 second before looking for next message");
+                  waitAWhile(1000);
                 }
             } catch (JMSRuntimeException jmsex) {
                 jmsex.printStackTrace();
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                }
+                waitAWhile(1000);
             }
         }
     }
@@ -281,5 +280,12 @@ public class JmsGet {
 
         logger.setLevel(LOGLEVEL);
         logger.finest("Logging initialised");
+    }
+
+    private static void waitAWhile(int duration) {
+        try {
+            Thread.sleep(duration);
+        } catch (InterruptedException e) {
+        }
     }
 }


### PR DESCRIPTION
In the message getters add a one second wait to allow other consumers running on the same machine to receive messages.