### PR TITLE
In JMS Samples allow location of env file to be overriden

### DIFF
--- a/JMS/README.md
+++ b/JMS/README.md
@@ -46,14 +46,14 @@ If you are using maven then a Jakarta enabled `pom-jakarta.xml` can be used.
 Encapsulates the reading of MQ environment variables and allows all the samples to use a common set.
 
 The location and name of the env.json file defaults 
-to `../env.json`. This can be overriden by setting the envrionment option `EnvFile`. 
+to `../env.json`. This can be overriden by setting the environment option `EnvFile`. 
 
 eg. 
 
 ````
 java -DEnvFile=../env.json -jar target/mq-dev-patterns-0.1.0.jar put 
 ````
-If the environment settings file isn't found then the CCDT, Queue Manager, Queue, and user credentials need to be provided as envrionment settings.
+If the environment settings file isn't found then the CCDT, Queue Manager, Queue, and user credentials need to be provided as environment settings.
 
 ````
 java -DEnvFile=../env-not-found.json -DQMGR=QM1 -DAPP_USER=app -DAPP_PASSWORD=app-passw0rd -DQUEUE_NAME=DEV.QUEUE.1 -DMQCCDTURL=file:///location/ccdt.json -jar target/mq-dev-patterns-0.1.0.jar put 
@@ -239,7 +239,7 @@ If you have used maven to build the samples, you can run
 
 The request sample will put a message and wait for a response until it either gets a response or you `ctrl+c` interrupt it.
 
-If you set the envrionment variable `REPLY_QUEUE_NAME` then the reply to queue will be set 
+If you set the environment variable `REPLY_QUEUE_NAME` then the reply to queue will be set 
 to that queue, otherwise a temporary queue is created. 
 
 In the second terminal;
@@ -260,9 +260,9 @@ If you have used maven to build the samples, you can run
 
 The response sample will get a message from the queue, process it and put the response on the reply to queue and keep looking for more messages to respond to till you ctrl+c interrupt it.
 
-If you set the envrionment variable `RESPONDER_INACTIVITY_TIMEOUT` to a number the responder will wait `RESPONDER_INACTIVITY_TIMEOUT` seconds for a request before timing out and ending.
+If you set the environment variable `RESPONDER_INACTIVITY_TIMEOUT` to a number the responder will wait `RESPONDER_INACTIVITY_TIMEOUT` seconds for a request before timing out and ending.
 
-If you set the envrionment variable `REQUEST_MESSAGE_EXPIRY` to a number the requester will set the message expiry to  `REQUEST_MESSAGE_EXPIRY` seconds. It will then wait for `REQUEST_MESSAGE_EXPIRY` seconds for a reply before timing out and ending.
+If you set the environment variable `REQUEST_MESSAGE_EXPIRY` to a number the requester will set the message expiry to  `REQUEST_MESSAGE_EXPIRY` seconds. It will then wait for `REQUEST_MESSAGE_EXPIRY` seconds for a reply before timing out and ending.
 
 
 ## The SampleEnvSetter

--- a/JMS/README.md
+++ b/JMS/README.md
@@ -21,7 +21,13 @@ If you want to use Jakarta Messaging in place of JMS, then use the following jar
 
 This will generate compilation errors. The code, however contains commented out blocks (mainly the import blocks) that you can uncomment to overcome the compilation errors. Remember to remove the JMS code blocks that need removing.
 
-If you are using maven then a Jakarta enabled `pom-jakarta.xml` can be used.
+If you are using maven then add -P JAKARTA to the mvn commands.
+eg. 
+```
+mvn clean package -P JAKARTA
+```
+
+Alternatively a Jakarta enabled `pom-jakarta.xml` can be used.
 
 
 ## Intro to JMS Samples
@@ -110,6 +116,13 @@ mvn clean package
 ````
 
 If you want to use the Jakarta messaging dependencies then run 
+either
+
+````
+mvn clean package -P JAKARTA
+````
+
+or
 
 ````
 mvn clean package -f pom-jakarta.xml

--- a/JMS/README.md
+++ b/JMS/README.md
@@ -45,7 +45,19 @@ If you are using maven then a Jakarta enabled `pom-jakarta.xml` can be used.
 **SampleEnvSetter.java** - Used by all stand alone samples to read the variable from the env.json. Used by the decoupled samples through the ConnectionHelper.
 Encapsulates the reading of MQ environment variables and allows all the samples to use a common set.
 
+The location and name of the env.json file defaults 
+to `../env.json`. This can be overriden by setting the envrionment option `EnvFile`. 
 
+eg. 
+
+````
+java -DEnvFile=../env.json -jar target/mq-dev-patterns-0.1.0.jar put 
+````
+If the environment settings file isn't found then the CCDT, Queue Manager, Queue, and user credentials need to be provided as envrionment settings.
+
+````
+java -DEnvFile=../env-not-found.json -DQMGR=QM1 -DAPP_USER=app -DAPP_PASSWORD=app-passw0rd -DQUEUE_NAME=DEV.QUEUE.1 -DMQCCDTURL=file:///location/ccdt.json -jar target/mq-dev-patterns-0.1.0.jar put 
+````
 
 ### Refactored samples to reduce duplication
 

--- a/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
+++ b/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
@@ -38,10 +38,19 @@ public class SampleEnvSetter {
     private static final String ZOS = "z/os";
     private static final int DEFAULT_MQI_PORT = 1414;
 
+    private static final String ENV_FILE = "EnvFile";
+    private static final String DEFAULT_ENV_FILE = "../env.json";    
+    private static final String DEFAULT_Z_ENV_FILE ="../env-zbindings.json";
+
     public SampleEnvSetter() {
         JSONObject mqEnvSettings = null;
         mqEndPoints = null;  
         File file = getEnvFile();
+
+        if (null == file) {
+            logger.warning("No Environment settings file found");
+            return;
+        }
 
         try {
             String content = new String(Files.readAllBytes(Paths.get(file.toURI())));
@@ -72,22 +81,28 @@ public class SampleEnvSetter {
     private File getEnvFile() {
         File file = null;
         boolean onZ = System.getProperty("os.name").toLowerCase().contains(ZOS);
-        if (onZ) {
+    
+        // Allow system setting to override env file location and name
+        String valueEnvFile = System.getProperty(ENV_FILE);
+        logger.warning(ENV_FILE + " is set to " + valueEnvFile);
+
+        if (null != valueEnvFile) {
+        } else if (onZ) {
             logger.info("Running on z/OS");
-            file = new File("../env-zbindings.json");
-            if (! file.exists()){
-                logger.info("Environment settings env-zbindings.json file not found");
-                file = null;
-            }   
+            valueEnvFile = DEFAULT_Z_ENV_FILE;
+        } else {
+            valueEnvFile = DEFAULT_ENV_FILE;
         }
-        if (null == file) {
-            file = new File("../env.json");
-            if (! file.exists()){
-                logger.info("Environment settings env.json file not found");
-                logger.info("If there are no envrionment overrides then the app will not be able to connect to MQ");
-                file = null;
-            }  
-        }   
+
+        logger.info("Looking for environment file " + valueEnvFile);
+
+        file = new File(valueEnvFile);
+        if (! file.exists()){
+            logger.warning("Environment settings " + valueEnvFile + " file not found");
+            logger.warning("As a minimum a queue manager, queue and CCDT will be required");
+            logger.warning("If not provided then the application will throw an exception");
+            file = null;
+        }       
         return file;     
     }
 
@@ -214,6 +229,8 @@ public class SampleEnvSetter {
     }
 
     public int getCount() {
-        return mqEndPoints.length();
+        // If there are no endpoints, then values 
+        // need to come from a CCDT and environment settings
+        return (null == mqEndPoints) ? 1 : mqEndPoints.length();
     }
 }

--- a/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
+++ b/JMS/com/ibm/mq/samples/jms/SampleEnvSetter.java
@@ -84,7 +84,7 @@ public class SampleEnvSetter {
     
         // Allow system setting to override env file location and name
         String valueEnvFile = System.getProperty(ENV_FILE);
-        logger.warning(ENV_FILE + " is set to " + valueEnvFile);
+        logger.info(ENV_FILE + " is set to " + valueEnvFile);
 
         if (null != valueEnvFile) {
         } else if (onZ) {

--- a/JMS/pom.xml
+++ b/JMS/pom.xml
@@ -30,8 +30,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <profiles>
@@ -71,7 +71,7 @@
         </dependency>
       </dependencies>
     </profile>
-    
+
   </profiles>
 
   <dependencies>

--- a/JMS/pom.xml
+++ b/JMS/pom.xml
@@ -34,23 +34,52 @@
     <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 
+  <profiles>
+
+    <profile>
+      <id>JMS</id> 
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation> 
+      <dependencies>
+        <dependency>
+            <groupId>javax.jms</groupId>
+            <artifactId>javax.jms-api</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm.mq</groupId>
+            <artifactId>com.ibm.mq.allclient</artifactId>
+            <version>9.3.4.0</version>
+        </dependency>  
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>JAKARTA</id>   
+
+      <dependencies>
+        <dependency>
+            <groupId>jakarta.jms</groupId>
+            <artifactId>jakarta.jms-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm.mq</groupId>
+            <artifactId>com.ibm.mq.jakarta.client</artifactId>
+            <version>9.3.4.0</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    
+  </profiles>
+
   <dependencies>
-    <dependency>
-        <groupId>javax.jms</groupId>
-        <artifactId>javax.jms-api</artifactId>
-        <version>2.0.1</version>
-    </dependency>
-    <dependency>
-        <groupId>com.ibm.mq</groupId>
-        <artifactId>com.ibm.mq.allclient</artifactId>
-        <version>9.3.4.0</version>
-    </dependency>
     <dependency>
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
         <version>20231013</version>
     </dependency>   
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
Add a `-DEnvFile` environment setting that allows the location and name of the environment to be overridden. If not provided then the default is `../env.json`

If the file can't be found then CCDT, QMGR, QUEUE and required app credentials need to be provided as `-D` options. 