### PR TITLE
Add a common exception handler that also works with JMSRuntimeException

### DIFF
--- a/JMS/com/ibm/mq/samples/jms/ConnectionHelper.java
+++ b/JMS/com/ibm/mq/samples/jms/ConnectionHelper.java
@@ -206,28 +206,8 @@ public class ConnectionHelper {
     }
 
     public static void recordFailure(Exception ex) {
-        if (ex != null) {
-            if (ex instanceof JMSException) {
-                processJMSException((JMSException) ex);
-            } else {
-                logger.warning(ex.getMessage());
-            }
-        }
-        System.out.println("FAILURE");
+        JmsExceptionHelper.recordFailure(logger,ex);
         return;
     }
 
-    private static void processJMSException(JMSException jmsex) {
-        logger.info(jmsex.getMessage());
-        Throwable innerException = jmsex.getLinkedException();
-        logger.info("Exception is: " + jmsex);
-        if (innerException != null) {
-            logger.info("Inner exception(s):");
-        }
-        while (innerException != null) {
-            logger.warning(innerException.getMessage());
-            innerException = innerException.getCause();
-        }
-        return;
-    }
 }

--- a/JMS/com/ibm/mq/samples/jms/ConsumerHelper.java
+++ b/JMS/com/ibm/mq/samples/jms/ConsumerHelper.java
@@ -50,29 +50,8 @@ public class ConsumerHelper {
         }
     }
 
-    private void recordFailure(Exception ex) {
-        if (ex != null) {
-            if (ex instanceof JMSException) {
-                processJMSException((JMSException) ex);
-            } else {
-                logger.warning(ex.getMessage());
-            }
-        }
-        logger.info("FAILURE");
-        return;
-    }
-
-    private void processJMSException(JMSException jmsex) {
-        logger.warning(jmsex.getMessage());
-        Throwable innerException = jmsex.getLinkedException();
-        logger.warning("Exception is: " + jmsex);
-        if (innerException != null) {
-            logger.warning("Inner exception(s):");
-        }
-        while (innerException != null) {
-            logger.warning(innerException.getMessage());
-            innerException = innerException.getCause();
-        }
+    private static void recordFailure(Exception ex) {
+        JmsExceptionHelper.recordFailure(logger,ex);
         return;
     }
 

--- a/JMS/com/ibm/mq/samples/jms/JmsExceptionHelper.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsExceptionHelper.java
@@ -1,0 +1,66 @@
+/*
+* (c) Copyright IBM Corporation 2019, 2023
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ibm.mq.samples.jms;
+
+import java.util.logging.Logger;
+
+import javax.jms.JMSException;
+import javax.jms.JMSRuntimeException;
+
+/*
+ * A helper class to report JMS exceptions in a common way
+ */
+public class JmsExceptionHelper {
+
+  static void recordFailure(Logger logger, Exception ex) {
+    if (ex != null) {
+      if (ex instanceof JMSException ||  ex instanceof JMSRuntimeException) {
+        processJMSException(logger, ex);
+      }
+      else {
+        logger.warning(ex.getMessage());
+      }
+    }
+    System.out.println("FAILURE");
+    return;
+  }
+
+  private static void processJMSException(Logger logger, Exception jmsex) {
+    logger.info(jmsex.getMessage());
+    Throwable innerException = null;
+    
+    if (jmsex instanceof JMSException) {
+      innerException = ((JMSException)jmsex).getLinkedException();
+    } else if (jmsex instanceof JMSRuntimeException) {
+      innerException = jmsex.getCause(); 
+    }
+    logger.warning("Exception is: " + jmsex);
+    
+    String errStack = "";
+    while (innerException != null) {
+      errStack += "\n  Caused by: " + innerException.getMessage();
+      innerException = innerException.getCause();
+    }
+    if (!errStack.isEmpty()) {
+      logger.warning(errStack);
+    }
+    // For more detailed information on the failure, uncomment the following line
+    // jmsex.printStackTrace();
+    return;
+  }
+
+}

--- a/JMS/com/ibm/mq/samples/jms/JmsGet.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsGet.java
@@ -241,30 +241,10 @@ public class JmsGet {
         return;
     }
 
+ 
     private static void recordFailure(Exception ex) {
-        if (ex != null) {
-            if (ex instanceof JMSException) {
-                processJMSException((JMSException) ex);
-            } else {
-                logger.warning(ex.getMessage());
-            }
-        }
-        System.out.println("FAILURE");
-        return;
-    }
-
-    private static void processJMSException(JMSException jmsex) {
-        logger.info(jmsex.getMessage());
-        Throwable innerException = jmsex.getLinkedException();
-        logger.info("Exception is: " + jmsex);
-        if (innerException != null) {
-            logger.info("Inner exception(s):");
-        }
-        while (innerException != null) {
-            logger.warning(innerException.getMessage());
-            innerException = innerException.getCause();
-        }
-        return;
+      JmsExceptionHelper.recordFailure(logger,ex);
+      return;
     }
 
     private static void initialiseLogging() {

--- a/JMS/com/ibm/mq/samples/jms/JmsPub.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsPub.java
@@ -205,28 +205,7 @@ public class JmsPub {
   }
 
   private static void recordFailure(Exception ex) {
-    if (ex != null) {
-      if (ex instanceof JMSException) {
-        processJMSException((JMSException) ex);
-      } else {
-        logger.info(ex.getMessage());
-      }
-    }
-    logger.warning("FAILURE");
-    return;
-  }
-
-  private static void processJMSException(JMSException jmsex) {
-    logger.info(jmsex.getMessage());
-    Throwable innerException = jmsex.getLinkedException();
-    logger.info("Exception is: " + jmsex);
-    if (innerException != null) {
-      logger.info("Inner exception(s):");
-    }
-    while (innerException != null) {
-      logger.warning(innerException.getMessage());
-      innerException = innerException.getCause();
-    }
+    JmsExceptionHelper.recordFailure(logger,ex);
     return;
   }
 

--- a/JMS/com/ibm/mq/samples/jms/JmsPut.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsPut.java
@@ -194,27 +194,7 @@ public class JmsPut {
     }
 
     private static void recordFailure(Exception ex) {
-        if (ex != null) {
-            if (ex instanceof JMSException) {
-                processJMSException((JMSException) ex);
-            } else {
-                logger.warning(ex.getMessage());
-            }
-        }
-        logger.warning("FAILURE");
-        return;
-    }
-
-    private static void processJMSException(JMSException jmsex) {
-        logger.warning(jmsex.getMessage());
-        Throwable innerException = jmsex.getLinkedException();
-        if (innerException != null) {
-            logger.warning("Inner exception(s):");
-        }
-        while (innerException != null) {
-            logger.warning(innerException.getMessage());
-            innerException = innerException.getCause();
-        }
+        JmsExceptionHelper.recordFailure(logger,ex);
         return;
     }
 

--- a/JMS/com/ibm/mq/samples/jms/JmsRequest.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsRequest.java
@@ -310,27 +310,7 @@ public class JmsRequest {
     }
 
     private static void recordFailure(Exception ex) {
-        if (ex != null) {
-            if (ex instanceof JMSException) {
-                processJMSException((JMSException) ex);
-            } else {
-                logger.warning(ex.getMessage());
-            }
-        }
-        logger.info("FAILURE");
-        return;
-    }
-
-    private static void processJMSException(JMSException jmsex) {
-        logger.warning(jmsex.getMessage());
-        Throwable innerException = jmsex.getLinkedException();
-        if (innerException != null) {
-            logger.warning("Inner exception(s):");
-        }
-        while (innerException != null) {
-            logger.warning(innerException.getMessage());
-            innerException = innerException.getCause();
-        }
+        JmsExceptionHelper.recordFailure(logger,ex);
         return;
     }
 

--- a/JMS/com/ibm/mq/samples/jms/JmsResponse.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsResponse.java
@@ -395,28 +395,7 @@ public class JmsResponse {
     }
 
     private static void recordFailure(Exception ex) {
-        if (ex != null) {
-            if (ex instanceof JMSException) {
-                processJMSException((JMSException) ex);
-            } else {
-                logger.warning(ex.getMessage());
-            }
-        }
-        logger.info("FAILURE");
-        return;
-    }
-
-    private static void processJMSException(JMSException jmsex) {
-        logger.info(jmsex.getMessage());
-        Throwable innerException = jmsex.getLinkedException();
-        logger.info("Exception is: " + jmsex);
-        if (innerException != null) {
-            logger.info("Inner exception(s):");
-        }
-        while (innerException != null) {
-            logger.warning(innerException.getMessage());
-            innerException = innerException.getCause();
-        }
+        JmsExceptionHelper.recordFailure(logger,ex);
         return;
     }
 

--- a/JMS/com/ibm/mq/samples/jms/JmsSub.java
+++ b/JMS/com/ibm/mq/samples/jms/JmsSub.java
@@ -196,28 +196,7 @@ public class JmsSub {
     }
 
     private static void recordFailure(Exception ex) {
-        if (ex != null) {
-            if (ex instanceof JMSException) {
-                processJMSException((JMSException) ex);
-            } else {
-                logger.warning(ex.getMessage());
-            }
-        }
-        logger.info("FAILURE");
-        return;
-    }
-
-    private static void processJMSException(JMSException jmsex) {
-        logger.warning(jmsex.getMessage());
-        Throwable innerException = jmsex.getLinkedException();
-        logger.warning("Exception is: " + jmsex);
-        if (innerException != null) {
-            logger.warning("Inner exception(s):");
-        }
-        while (innerException != null) {
-            logger.warning(innerException.getMessage());
-            innerException = innerException.getCause();
-        }
+        JmsExceptionHelper.recordFailure(logger,ex);
         return;
     }
 


### PR DESCRIPTION
The previous code did not deal with JMSRuntimeExceptions, which meant is was very difficult when I was trying to debug connection failures with S's tests.
This makes a common part that all the relevant programs can use - there's probably more commonality possible, but this solves the primary problem.