### PR TITLE
Fix to debug message

### DIFF
--- a/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Requestor.js
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Requestor.js
@@ -70,7 +70,8 @@ class Requestor {
                 resolve(hObjDyn);
             })
             .catch((err) => {
-                debug_warn(`requester ${this.myID} error putting message onto queue ${hObjDyn}`);
+                debug_warn(`requester ${this.myID} error putting message onto queue`);
+                debug_warn(err);
                 reject(err);
             })
         });


### PR DESCRIPTION
Fix to debug message, which was throwing an exception as it was referring to an out of scope parameter.