### PR TITLE
Be build fix

### DIFF
--- a/ibm-messaging-mq-cloud-showcase-app/backend/Dockerfile
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/Dockerfile
@@ -27,6 +27,7 @@ ENV APP_DIR /usr/local
 WORKDIR ${APP_DIR}
 
 # Update npm to latest version
+# Removed as was causing "Class extends ..." error
 # RUN npm install -g npm
 
 # Copy project files into the container
@@ -34,7 +35,6 @@ COPY ./AWS-showcase-backend ./AWS-showcase-backend
 ENV APP_DIR /usr/local/AWS-showcase-backend/
 WORKDIR ${APP_DIR}
 
-# Force clean the cache, to prevent "Class extends value undefined ... " error  
 # Install packages for the application
 RUN npm install --omit=dev \   
     && chmod a+rx ${APP_DIR}/*

--- a/ibm-messaging-mq-cloud-showcase-app/backend/Dockerfile
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/Dockerfile
@@ -35,7 +35,7 @@ ENV APP_DIR /usr/local/AWS-showcase-backend/
 WORKDIR ${APP_DIR}
 
 #install packages for the application
-RUN npm install --only=prod \   
+RUN npm install --omit=dev \   
     && chmod a+rx ${APP_DIR}/*
 
 #Cleaning

--- a/ibm-messaging-mq-cloud-showcase-app/backend/Dockerfile
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/Dockerfile
@@ -27,7 +27,7 @@ ENV APP_DIR /usr/local
 WORKDIR ${APP_DIR}
 
 # Update npm to latest version
-RUN npm install -g npm
+# RUN npm install -g npm
 
 # Copy project files into the container
 COPY ./AWS-showcase-backend ./AWS-showcase-backend
@@ -36,8 +36,7 @@ WORKDIR ${APP_DIR}
 
 # Force clean the cache, to prevent "Class extends value undefined ... " error  
 # Install packages for the application
-RUN npm cache clean --force \
-    && npm install --omit=dev \   
+RUN npm install --omit=dev \   
     && chmod a+rx ${APP_DIR}/*
 
 #Cleaning

--- a/ibm-messaging-mq-cloud-showcase-app/backend/Dockerfile
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/Dockerfile
@@ -34,8 +34,10 @@ COPY ./AWS-showcase-backend ./AWS-showcase-backend
 ENV APP_DIR /usr/local/AWS-showcase-backend/
 WORKDIR ${APP_DIR}
 
-#install packages for the application
-RUN npm install --omit=dev \   
+# Force clean the cache, to prevent "Class extends value undefined ... " error  
+# Install packages for the application
+RUN npm cache clean --force \
+    && npm install --omit=dev \   
     && chmod a+rx ${APP_DIR}/*
 
 #Cleaning


### PR DESCRIPTION
Be was failing to build in Code Engine, failing with a "Class extends value undefined ..." error, which appears to be due to contamination of dependencies.