### PR TITLE
Poison Message Handler

### DIFF
--- a/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
@@ -41,7 +41,7 @@ class Responder {
                     debug_warn("This is not a reply to queue valid message");
                     resolve(null);
                 } else if (messages[0].replyToMsg) {
-                    this.mqclient.checkQueueExists(messages[0].replyToMsg, this.appId)
+                    this.mqclient.checkReplyToQueueExists(messages[0].replyToMsg)
                     .then((flag) => {
                         if (!flag) {
                             debug_warn("Some Poison Message");

--- a/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022, 2023 IBM Corp.
+ * Copyright 2022, 2024 IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
@@ -34,18 +34,18 @@ class Responder {
             this.mqclient.get(queueName,1,null, 'DYNAMIC', this.appId)
             .then((messages) => {
                 debug_warn(`The producer retrieved this message ${JSON.stringify(messages)}`);
-                if(messages.length === 0) {
+                if (messages.length === 0) {
                     debug_info("Poison Message");
                     resolve();
-                } else if(!messages[0].replyToMsg) {
+                } else if (!messages[0].replyToMsg) {
                     debug_warn("This is not a reply to queue valid message");
                     resolve(null);
-                } else if(messages[0].replyToMsg) {
+                } else if (messages[0].replyToMsg) {
                     this.mqclient.checkQueueExists(messages[0].replyToMsg, this.appId)
                     .then((flag) => {
                         if (flag === false) {
                             debug_info("Some Poison Message");
-                            resolve(null);
+                            resolve(messages);
                         } else {
                             debug_info(`Responder ${this.myID} obtained message from queue`);
                             resolve(messages);

--- a/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
@@ -36,7 +36,7 @@ class Responder {
                 debug_warn(`The producer retrieved this message ${JSON.stringify(messages)}`);
                 if (messages.length === 0) {
                     debug_info("Poison Message");
-                    resolve();
+                    resolve(null);
                 } else if (!messages[0].replyToMsg) {
                     debug_warn("This is not a reply to queue valid message");
                     resolve(null);
@@ -44,11 +44,14 @@ class Responder {
                     this.mqclient.checkQueueExists(messages[0].replyToMsg, this.appId)
                     .then((flag) => {
                         if (flag === false) {
-                            debug_info("Some Poison Message");
+                            debug_warn("Some Poison Message");
+                            messages[0].replyToMsg = null;
+                            messages[0].msgObject = null;
+                            resolve(messages);
                         } else {
                             debug_info(`Responder ${this.myID} obtained message from queue`);
+                            resolve(messages);
                         }
-                        resolve(messages);
                     })
                     .catch((err) => {
                         debug_warn("Some error has occured : ", err);

--- a/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
@@ -45,11 +45,10 @@ class Responder {
                     .then((flag) => {
                         if (flag === false) {
                             debug_info("Some Poison Message");
-                            resolve(messages);
                         } else {
                             debug_info(`Responder ${this.myID} obtained message from queue`);
-                            resolve(messages);
                         }
+                        resolve(messages);
                     })
                     .catch((err) => {
                         debug_warn("Some error has occured : ", err);

--- a/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
@@ -41,7 +41,7 @@ class Responder {
                     debug_warn("This is not a reply to queue valid message");
                     resolve(null);
                 } else if (messages[0].replyToMsg) {
-                    this.mqclient.checkReplyToQueueExists(messages[0].replyToMsg)
+                    this.mqclient.checkQueueExists(messages[0].replyToMsg)
                     .then((flag) => {
                         if (!flag) {
                             debug_warn("Some Poison Message");

--- a/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/models/Responder.js
@@ -43,7 +43,7 @@ class Responder {
                 } else if (messages[0].replyToMsg) {
                     this.mqclient.checkQueueExists(messages[0].replyToMsg, this.appId)
                     .then((flag) => {
-                        if (flag === false) {
+                        if (!flag) {
                             debug_warn("Some Poison Message");
                             messages[0].replyToMsg = null;
                             messages[0].msgObject = null;

--- a/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/msms/message-session-manager.js
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/msms/message-session-manager.js
@@ -91,12 +91,11 @@ class MQClient {
   }
 
   /**
- * Checks if a reply to queue exists or not
- * @param {Object} replyToMsg The reply to queue value
- * @param {Object} appId The current session id.
+ * Checks if a Reply to Queue needed in a Req-Rep scenario exists or not.
+ * @param {Object} replyToMsg The reply to queue value present in the message body. (This is present in the message structure of the Put function)
  * @returns {Promise<any>} Returns a promise resolving to true if the reply to queue exists, else resolves with a false.
  */
-  checkQueueExists(replyToMsg, appId) {
+  checkReplyToQueueExists(replyToMsg) {
     // If the HCONN doesn't exist, that means the Requesting application did not perform a connection to the queue, and the message being consumed is a potential poison message.
     if (this[_HCONNKEY]===null) {
       let qmgr = MQDetails.QMGR;

--- a/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/msms/message-session-manager.js
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/msms/message-session-manager.js
@@ -91,12 +91,12 @@ class MQClient {
   }
 
   /**
- * Checks if a Reply to Queue needed in a Req-Rep scenario exists or not.
- * @param {Object} replyToMsg The reply to queue value present in the message body. (This is present in the message structure of the Put function)
- * @returns {Promise<any>} Returns a promise resolving to true if the reply to queue exists, else resolves with a false.
+ * Checks if a particular queue definition exists or not.
+ * @param {Object} queueName Name of the queue whose definition is to be checked of whether it exists or not. 
+ * @returns {Promise<any>} Returns a promise resolving to true if the queue definition exists, else resolves with a false.
  */
-  checkReplyToQueueExists(replyToMsg) {
-    // If the HCONN doesn't exist, that means the Requesting application did not perform a connection to the queue, and the message being consumed is a potential poison message.
+  checkQueueExists(queueName) {
+    // If the HCONN doesn't exist, that means a connection to the Queue Manager was not performed.
     if (this[_HCONNKEY]===null) {
       let qmgr = MQDetails.QMGR;
       return new Promise((resolve,reject) => {
@@ -108,14 +108,14 @@ class MQClient {
             debug_info("HCONN IS : ", hConn);
             try {
               let od = new mq.MQOD();
-              od.ObjectName = replyToMsg;
+              od.ObjectName = queueName;
               od.ObjectType = MQC.MQOT_Q;
               let openOptions = MQC.MQOO_OUTPUT;
 
               mq.Open(hConn, od, openOptions, function (err, hObj) {
                 if (err) {
                   if (err.mqrc === MQC.MQRC_UNKNOWN_OBJECT_NAME) {
-                    debug_warn("REPLY TO Q DOES NOT EXIST");
+                    debug_warn("Queue does not exist");
                     resolve(false);
                   }
                 } else {

--- a/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/msms/message-session-manager.js
+++ b/ibm-messaging-mq-cloud-showcase-app/backend/AWS-showcase-backend/msms/message-session-manager.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022, 2023 IBM Corp.
+ * Copyright 2022, 2024 IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
@@ -120,6 +120,14 @@ class MQClient {
                     resolve(false);
                   }
                 } else {
+                  mq.Close(hObj, 0, function(err) {
+                    if (err) {
+                      debug_warn("Error while closing connection : ", err);
+                    } else {
+                      debug_info("MQCLOSE successfull");
+                    }
+                  });
+
                   resolve(true);
                 }
               })


### PR DESCRIPTION
- Handles the situation when a Requestor puts a message into the queue, following which the backend container goes down, and then it comes back up, resulting in a poison message.
- The logic which I have applied is that when the poison message is consumed, we perform a `MQOPEN` on the `replyToQ` , and if a `MQRC_UNKNOWN_OBJECT` is raised, we know that the reply to queue does not exist anymore, and we can conclude that the message is indeed a poison message.
- I implemented a Promise which resolves to true if the reply to queue exists, else resolves to false. This is then handled in the `Responder` file, where a false value is dealt with a simple output message, and a `resolve(null)` value. 