### PR TITLE
Fix for run mode arguments for quarkus amqp sample

### DIFF
--- a/amqp-qpid/qpid-quarkus/src/main/java/com/ibm/mq/samples/jms/quarkus/AMQPTestConfig.java
+++ b/amqp-qpid/qpid-quarkus/src/main/java/com/ibm/mq/samples/jms/quarkus/AMQPTestConfig.java
@@ -35,6 +35,7 @@ public class AMQPTestConfig {
     @ConfigProperty(name = "amqp-mqtest.replyqueuename")
     private Optional<String> replyqueuename;
 
+    @ConfigProperty(name = "amqp-mqtest.appargs")
     private List<String> appargs;
 
     public Optional<String> getQueueName() { return queuename; }


### PR DESCRIPTION
Last quarkus bump missed the setting for `amqp-mqtest.appargs`