### PR TITLE
Fixes and cleanup on the AMQP Go sample

### DIFF
--- a/amqp/Go/README.md
+++ b/amqp/Go/README.md
@@ -6,16 +6,16 @@ The Go samples are based on go-amqp (a Go AMQP 1.0 client implementation) as pro
 2. amqpConsumer.go
 
 ### amqpProducer.go
-This Go application is used to put 10 messages from the client to the destination in the broker (IBM MQ). Messages can be put either onto a Queue or a Topic. 
+This Go application is used to put 10 messages from the client to the destination in the broker (IBM MQ). Messages can be put either onto a Queue or a Topic.
 Following are the parameters that can be passed to the application:
 ```
 -t : Topic name
 -q : Queue name
 ```
-Any one parameter must be used. That is, either a Queue or a Topic.
+One parameter only must be used. That is, either a Queue or a Topic.
 
 ### amqpConsumer.go
-This Go application is used to get messages from the destination in the broker (IBM MQ) back to the client. Messages can be received either from a Queue or a Topic. 
+This Go application is used to get messages from the destination in the broker (IBM MQ) back to the client. Messages can be received either from a Queue or a Topic.
 Following are the parameters that can be passed to the application:
 ```
 -t : Topic name

--- a/amqp/Go/amqpConsumer.go
+++ b/amqp/Go/amqpConsumer.go
@@ -1,7 +1,7 @@
 /****************************************************************************************/
 /*                                                                                      */
 /*                                                                                      */
-/*  Copyright 2023 IBM Corp.                                                            */
+/*  Copyright 2023, 2025 IBM Corp.                                                      */
 /*                                                                                      */
 /*  Licensed under the Apache License, Version 2.0 (the "License");                     */
 /*  you may not use this file except in compliance with the License.                    */
@@ -34,182 +34,188 @@
 /*  -t ==> TopicName                                                                    */
 /*  -q ==> QueueName                                                                    */
 /****************************************************************************************/
- 
+
 package main
 
 import (
-    "log"
-    "fmt"
-    "context"
-    "flag"
-    "encoding/json"
-    "io/ioutil"
-    "os"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
 
-    "github.com/Azure/go-amqp"
+	"github.com/Azure/go-amqp"
 )
 
 type Env struct {
-    Username         string `json:"APP_USER"`
-    Password         string `json:"APP_PASSWORD"`
-    Host             string `json:"HOST"`
-    Port             string `json:"PORT"`
+	Username string `json:"APP_USER"`
+	Password string `json:"APP_PASSWORD"`
+	Host     string `json:"HOST"`
+	Port     string `json:"PORT"`
 }
 
 type MQEndpoints struct {
-    Points []Env `json:"MQ_ENDPOINTS"`
+	Points []Env `json:"MQ_ENDPOINTS"`
 }
 
 var (
-    queueName   string
-    topicName   string
-    valid       bool
-    destination string
-    isQueue     bool
+	queueName   string
+	topicName   string
+	destination string
+	isQueue     bool
 )
 var EnvSettings Env
 var MQ_ENDPOINTS MQEndpoints
 
-//Parsing the command line arguments
-func init() {
-    flag.StringVar(&queueName, "q", "DEMO", "Queue")
-    flag.StringVar(&topicName, "t", "TOP", "Topic")
-    flag.Parse()
-    if flag.NFlag() > 2 {
-        valid = false
-    } else if flag.NFlag() == 1 {
-        flag.Visit(func(f *flag.Flag) {
-            if f.Name == "q" || f.Name == "t" {
-                valid = true
-            }
-            if f.Name == "q"{
-                destination = queueName
-                isQueue = true
-            }else{
-                destination = topicName
-            }
-        })
-    } else {
-        valid = false
-    }
+// Parsing the command line arguments
+func parseArgs() {
+	flag.StringVar(&queueName, "q", "", "Queue")
+	flag.StringVar(&topicName, "t", "", "Topic")
+	flag.Parse()
 
-    if valid{
-        parseEnv()
-    }
+	// One, and only one, of the parameters must be provided
+	if (queueName == "" && topicName == "") ||
+		(queueName != "" && topicName != "") {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if queueName != "" {
+		isQueue = true
+		destination = queueName
+	} else {
+		destination = topicName
+	}
 }
 
 func main() {
-    if !valid || queueName=="" || topicName==""{
-        fmt.Println("Invalid arguments")
-        return
-    }
-    fmt.Println("Application is Starting...")
 
-    //Defining the AMQP URI
-    uri:= "amqp://"+EnvSettings.Username+":"+EnvSettings.Password+"@"+EnvSettings.Host+":"+EnvSettings.Port
+	parseArgs()
+	parseEnv()
 
-    // Set up a new connection
-    conn, err := connect(uri)
-    if err != nil{
-        log.Fatal("Error in creating connection: ", err)
-    }
+	fmt.Println("Application is Starting...")
 
-    // Create a session
-    session, err := createSession(conn)
-    if err != nil{
-        log.Fatal("Error in creating a session: ", err)
-    }
+	//Defining the AMQP URI
+	uri := "amqp://" + EnvSettings.Username + ":" + EnvSettings.Password + "@" + EnvSettings.Host + ":" + EnvSettings.Port
 
-    //When the destination is a queue, capability must be set to "queue". If not, topic is selected by default.
-    ReceiverOptions := &amqp.ReceiverOptions{
-        SourceCapabilities: []string{"topic"},
-    }
-    if isQueue{
-        ReceiverOptions = &amqp.ReceiverOptions{
-            SourceCapabilities: []string{"queue"},
-        }
-    }
+	// Set up a new connection
+	conn, err := connect(uri)
+	if err != nil {
+		log.Fatal("Error in creating connection: ", err)
+	}
 
-    // Create a Receiver
-    Receiver, err := createReceiver(session, ReceiverOptions)
-    if err != nil{
-        log.Fatal("Error in creating a Receiver: ", err)
-    }
+	// Create a session
+	session, err := createSession(conn)
+	if err != nil {
+		log.Fatal("Error in creating a session: ", err)
+	}
 
-    //Recieve the messages
-    err = receiveMessages(Receiver)
-    if err != nil{
-        fmt.Println("Error while receiving messages: ",err)
-    }
-    fmt.Println("End of Sample amqpConsumer.go")
+	//When the destination is a queue, capability must be set to "queue". If not, topic is selected by default.
+	ReceiverOptions := &amqp.ReceiverOptions{
+		SourceCapabilities: []string{"topic"},
+	}
+	if isQueue {
+		ReceiverOptions = &amqp.ReceiverOptions{
+			SourceCapabilities: []string{"queue"},
+		}
+	}
+
+	// Create a Receiver
+	Receiver, err := createReceiver(session, ReceiverOptions)
+	if err != nil {
+		log.Fatal("Error in creating a Receiver: ", err)
+	}
+
+	//Recieve the messages
+	err = receiveMessages(Receiver)
+	if err != nil {
+		fmt.Println("Error while receiving messages: ", err)
+	}
+	fmt.Println("End of Sample amqpConsumer.go")
 }
 
-func connect(uri string) (*amqp.Conn, error){
-    conn, err := amqp.Dial(context.TODO(), uri, nil)
-    if err != nil {
-        return nil, err
-    }
-    fmt.Println("Connected to host.")
-    return conn, nil
+func connect(uri string) (*amqp.Conn, error) {
+
+	conn, err := amqp.Dial(context.TODO(), uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println("Connected to host.")
+	return conn, nil
 }
 
-func createSession(conn *amqp.Conn) (*amqp.Session, error){
-    session, err := conn.NewSession(context.TODO(), nil)
-    if err != nil {
-        return nil, err
-    }
-    fmt.Println("Session created.")
-    return session, nil
+func createSession(conn *amqp.Conn) (*amqp.Session, error) {
+
+	session, err := conn.NewSession(context.TODO(), nil)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println("Session created.")
+	return session, nil
 }
 
-func createReceiver(session *amqp.Session, receiverOptions *amqp.ReceiverOptions) (*amqp.Receiver, error){
-    receiver, err := session.NewReceiver(context.TODO(), destination, receiverOptions)
-    if err != nil {
-        return nil, err
-    }
-    fmt.Println("Receiver mapped to destination.")
-    fmt.Println("Destination :",receiverOptions.SourceCapabilities)
-    return receiver, nil
+func createReceiver(session *amqp.Session, receiverOptions *amqp.ReceiverOptions) (*amqp.Receiver, error) {
+	receiver, err := session.NewReceiver(context.TODO(), destination, receiverOptions)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println("Receiver mapped to destination: ", destination)
+	fmt.Println("Destination :", receiverOptions.SourceCapabilities)
+	return receiver, nil
 }
 
-func receiveMessages(receiver *amqp.Receiver) error{
-    for{
-        msg, err := receiver.Receive(context.TODO(), nil)
-        if msg != nil{
-            fmt.Println("Received message: ",string(msg.GetData()))
-            receiver.AcceptMessage(context.TODO(), msg)
-        }else{
-            fmt.Println("No More Messages")
-            return nil
-        }
-        if err != nil{
-            return err
-        }
-    }
+func receiveMessages(receiver *amqp.Receiver) error {
+
+	// The receiver is given a 5s timeout. If no messages are
+	// available in that time, the function ends
+	timeout, _ := time.ParseDuration("5s")
+
+	for {
+		// Create a new Context from a parent
+		c, _ := context.WithTimeout(context.TODO(), timeout)
+
+		// And use it in the Receive call
+		msg, err := receiver.Receive(c, nil)
+		if err != nil {
+			return err
+		} else {
+			if msg != nil {
+				fmt.Println("Received message: ", string(msg.GetData()))
+				receiver.AcceptMessage(c, msg)
+			} else {
+				fmt.Println("No More Messages")
+				return nil
+			}
+		}
+
+	}
 }
 
 // ***********Configuring MQ Credentials***********
 // Read MQ configuration from env.json
-//Check for file path in env variable ENV_FILE else default to ../env.json
-func parseEnv(){
-    DEFAULT_ENV_FILE := "../env.json"
-    filePath := os.Getenv("ENV_FILE")
-    if filePath != ""{
-        fmt.Println("ENV file is set to " + filePath)
-    } else{
-        fmt.Println("Using default ENV file: "+DEFAULT_ENV_FILE)
-        filePath = DEFAULT_ENV_FILE
-    }
-    content, err := ioutil.ReadFile(filePath)
-    if err != nil {
-        log.Fatal("Error when opening file: ", err)
-    }
-    // Unmarshall the data
-    err = json.Unmarshal(content, &MQ_ENDPOINTS)
-    if err != nil {
-        log.Fatal("Error during Unmarshal(): ", err)
-    }
-    if len(MQ_ENDPOINTS.Points) > 0 {
-        EnvSettings = MQ_ENDPOINTS.Points[0]
-    }
+// Check for file path in env variable ENV_FILE else default to ./env.json
+func parseEnv() {
+	DEFAULT_ENV_FILE := "./env.json"
+	filePath := os.Getenv("ENV_FILE")
+	if filePath != "" {
+		fmt.Println("ENV file is set to " + filePath)
+	} else {
+		fmt.Println("Using default ENV file: " + DEFAULT_ENV_FILE)
+		filePath = DEFAULT_ENV_FILE
+	}
+	content, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		log.Fatal("Error when opening file: ", err)
+	}
+	// Unmarshall the data
+	err = json.Unmarshal(content, &MQ_ENDPOINTS)
+	if err != nil {
+		log.Fatal("Error during Unmarshal(): ", err)
+	}
+	if len(MQ_ENDPOINTS.Points) > 0 {
+		EnvSettings = MQ_ENDPOINTS.Points[0]
+	}
 }

--- a/amqp/Go/env.json
+++ b/amqp/Go/env.json
@@ -1,0 +1,11 @@
+{
+  "MQ_ENDPOINTS": [
+    {
+      "HOST": "localhost",
+      "PORT": "5672",
+      "APP_USER": "app",
+      "APP_PASSWORD": "passw0rd"
+    }
+  ]
+}
+

--- a/amqp/Go/go.mod
+++ b/amqp/Go/go.mod
@@ -2,4 +2,4 @@ module AmqpGolang
 
 go 1.20
 
-require github.com/Azure/go-amqp v1.0.2 // indirect
+require github.com/Azure/go-amqp v1.0.2

--- a/amqp/Go/go.sum
+++ b/amqp/Go/go.sum
@@ -1,2 +1,8 @@
 github.com/Azure/go-amqp v1.0.2 h1:zHCHId+kKC7fO8IkwyZJnWMvtRXhYC0VJtD0GYkHc6M=
 github.com/Azure/go-amqp v1.0.2/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
* Make the parameter parsing more consistent and accurate (no implied defaults which were not being used anyway)
* Use a local env.json file that has only the fields we need: in particular, the AMQP port is not the same as the regular MQ port
* Correct the Consumer so it 
  *  works - error handling was wrong previously
  * has a receive timeout instead of hanging indefinitely