### PR TITLE
vertx-amqp-client and maven.compiler.source version upgrades

### DIFF
--- a/reactive-amqp/amqp-vertx/pom.xml
+++ b/reactive-amqp/amqp-vertx/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
-
 <!--
   (c) Copyright IBM Corporation 2020
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -15,23 +14,20 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
-
-    <groupId>example</groupId>
-    <artifactId>receiver-example</artifactId>
-    <version>1</version>
-    <dependencies>
-        <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-amqp-client</artifactId>
-            <version>4.2.1</version>
-        </dependency>
-    </dependencies>
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+  <groupId>example</groupId>
+  <artifactId>receiver-example</artifactId>
+  <version>1</version>
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-amqp-client</artifactId>
+      <version>4.5.14</version>
+    </dependency>
+  </dependencies>
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+  </properties>
 </project>


### PR DESCRIPTION
## Dependencies

- Updated `vertx-amqp-client` 4.2.1 → 4.5.14
- Updated Java `maven.compiler.source/target` 1.8 → `maven.compiler.release` 21

## Testing

- Tested on Java 21 and Java 25 on Linux x86_64 (RHEL 10) and macOS Apple Silicon
- Application compiles and receives messages successfully with updated dependencies