### PR TITLE
fix: pin terraform-aws-modules/vpc to ~> 5.0 to resolve provider vers…

### DIFF
--- a/container/queuemanager/terraform-aws/multi-step-with-efs/01-vpc/main.tf
+++ b/container/queuemanager/terraform-aws/multi-step-with-efs/01-vpc/main.tf
@@ -17,6 +17,7 @@
 # Create a new VPC making use of the terraform aws vpc module
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
 
   name = "mq-ecs-vpc-${var.name_suffix}"
   cidr = var.vpc_cidr_block


### PR DESCRIPTION
Without a version pin, terraform init pulled the latest vpc module (v6.7.2)
which requires hashicorp/aws >= 6.28.0. This conflicts with the existing
provider constraint of ~> 5.0 (< 6.0), causing terraform init to fail.